### PR TITLE
Plexbmc additions + indentation fix

### DIFF
--- a/skin.alienui/720p/Home.xml
+++ b/skin.alienui/720p/Home.xml
@@ -958,7 +958,7 @@
 						<visible>!Skin.HasSetting(HomeMenuNoVideosButton)</visible>
 					</item>
 					<item id="92">
-						<label>PLEX</label>
+						<label>31850</label>
 						<onclick>ActivateWindow(10025,&quot;plugin://plugin.video.plexbmc/?content_type=video&quot;,return)</onclick>
 						<icon>icon_video.png</icon>
 						<thumb>-</thumb>

--- a/skin.alienui/720p/Home.xml
+++ b/skin.alienui/720p/Home.xml
@@ -972,13 +972,13 @@
 						<visible>!Skin.HasSetting(HomeMenuNoTVShowButton) + Library.HasContent(TVShows)</visible>
 					</item>
 					<item id="91">
-                        <label>31842</label> <!-- Games -->
-                        <onclick condition="!System.Platform.Android">ActivateWindow(Programs,Addons,return)</onclick>
+                        			<label>31842</label> <!-- Games -->
+                        			<onclick condition="!System.Platform.Android">ActivateWindow(Programs,Addons,return)</onclick>
 						<onclick condition="System.Platform.Android">ActivateWindow(Programs)</onclick>
-                        <!--onclick>XBMC.RunScript("special://skin\scripts\launch_steam.py")</onclick-->
-                        <icon>alienware/icon_Helpcontroller.png</icon>
-                        <visible>!Skin.HasSetting(HomeMenuNoGamesButton)</visible>
-                    </item>
+                        			<!--onclick>XBMC.RunScript("special://skin\scripts\launch_steam.py")</onclick-->
+                        			<icon>alienware/icon_Helpcontroller.png</icon>
+			                        <visible>!Skin.HasSetting(HomeMenuNoGamesButton)</visible>
+                			</item>
 					<item id="3">
 						<label>31956</label>
 						<onclick>ActivateWindow(Music)</onclick>

--- a/skin.alienui/720p/Home.xml
+++ b/skin.alienui/720p/Home.xml
@@ -957,6 +957,13 @@
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoVideosButton)</visible>
 					</item>
+					<item id="92">
+						<label>PLEX</label>
+						<onclick>ActivateWindow(10025,&quot;plugin://plugin.video.plexbmc/?content_type=video&quot;,return)</onclick>
+						<icon>icon_video.png</icon>
+						<thumb>-</thumb>
+						<visible>System.HasAddon(plugin.video.plexbmc)</visible>
+					</item>
 					<item id="10">
 						<label>31954</label>
 						<onclick>ActivateWindow(Videos,MovieTitles,return)</onclick>

--- a/skin.alienui/language/English (Australia)/strings.po
+++ b/skin.alienui/language/English (Australia)/strings.po
@@ -1,4 +1,4 @@
-# Kodi Media Center language file
+﻿# Kodi Media Center language file
 # Addon Name: Confluence
 # Addon id: skin.confluence
 # Addon Provider: Jezz_X, Team Kodi
@@ -942,6 +942,10 @@ msgstr ""
 
 msgctxt "#31849"
 msgid "Support Wiki"
+msgstr ""
+
+msgctxt "#31850"
+msgid "PLEX"
 msgstr ""
 
 msgctxt "#31841"

--- a/skin.alienui/language/English (New Zealand)/strings.po
+++ b/skin.alienui/language/English (New Zealand)/strings.po
@@ -1,4 +1,4 @@
-# Kodi Media Center language file
+﻿# Kodi Media Center language file
 # Addon Name: Confluence
 # Addon id: skin.confluence
 # Addon Provider: Jezz_X, Team Kodi
@@ -942,6 +942,10 @@ msgstr ""
 
 msgctxt "#31849"
 msgid "Support Wiki"
+msgstr ""
+
+msgctxt "#31850"
+msgid "PLEX"
 msgstr ""
 
 msgctxt "#31841"

--- a/skin.alienui/language/English (US)/strings.po
+++ b/skin.alienui/language/English (US)/strings.po
@@ -1,4 +1,4 @@
-# Kodi Media Center language file
+﻿# Kodi Media Center language file
 # Addon Name: Confluence
 # Addon id: skin.confluence
 # Addon Provider: Jezz_X, Team Kodi
@@ -942,6 +942,10 @@ msgstr ""
 
 msgctxt "#31849"
 msgid "Support Wiki"
+msgstr ""
+
+msgctxt "#31850"
+msgid "PLEX"
 msgstr ""
 
 msgctxt "#31841"

--- a/skin.alienui/language/English/strings.po
+++ b/skin.alienui/language/English/strings.po
@@ -1,4 +1,4 @@
-# Kodi Media Center language file
+﻿# Kodi Media Center language file
 # Addon Name: Confluence
 # Addon id: skin.confluence
 # Addon Provider: Jezz_X, Team Kodi
@@ -1023,6 +1023,10 @@ msgstr ""
 
 msgctxt "#31849"
 msgid "Support Wiki"
+msgstr ""
+
+msgctxt "#31850"
+msgid "PLEX"
 msgstr ""
 
 msgctxt "#31841"


### PR DESCRIPTION
Adds menu item to launch PleXBMC directly.  

Only visible if the PleXBMC add on is installed and enabled. Makes the experience seamless to use Plex through the interface without cluttering the menu or settings if you don't need it.  

Matches current code structure and fixes indentation for the Games menu item.   

I don't know if this is something you are interested in adding, but it would be no maintenence and wouldn't  add any complications to future additions.  

Let me know if you're okay with community additions. If not, I will delete the PR and just keep modifying future releases for myself.
